### PR TITLE
Add Coolify deployment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git and local tooling
+/.git/
+/.gitignore
+/.bundle/
+/.ruby-lsp/
+
+# Secrets and environment files
+/.env*
+/config/master.key
+/config/credentials/*.key
+
+# Runtime and generated files
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+/tmp/pids/*
+!/tmp/pids/.keep
+/storage/*
+!/storage/.keep
+/node_modules/
+/coverage/
+/app/assets/builds/*
+!/app/assets/builds/.keep
+/public/assets/
+
+# Files not required by the production image
+/.github/
+/spec/
+/test/
+/.devcontainer/
+/Dockerfile*
+/.dockerignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,14 @@ env:
   COVERAGE_RETENTION_DAYS: 3
 
 jobs:
+  build_image:
+    name: Build production image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build production image
+        run: docker build --tag seepalette-admin:test .
+
   run_tests:
     name: Run tests
     runs-on: ubuntu-latest
@@ -42,6 +50,7 @@ jobs:
         run: bin/rails zeitwerk:check
       - name: Check production assets
         env:
+          APP_HOST: example.invalid
           RAILS_ENV: production
           SECRET_KEY_BASE_DUMMY: 1
           SKIP_BUN_INSTALL: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1
+# check=error=true
+
+# This image is intended for production deployments through Coolify.
+ARG RUBY_VERSION=4.0.6
+FROM docker.io/library/ruby:${RUBY_VERSION}-slim AS base
+
+WORKDIR /rails
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client && \
+    ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development:test" \
+    LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+
+FROM base AS build
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential git libpq-dev pkg-config xz-utils && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+ARG NODE_VERSION=22.23.2
+ARG YARN_VERSION=1.22.19
+RUN ARCH="$(dpkg --print-architecture)" && \
+    case "$ARCH" in \
+      amd64) NODE_ARCH="x64" ;; \
+      arm64) NODE_ARCH="arm64" ;; \
+      *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" | \
+      tar -xJ -C /usr/local --strip-components=1 && \
+    npm install --global "yarn@${YARN_VERSION}"
+
+COPY Gemfile Gemfile.lock .ruby-version ./
+RUN bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+COPY . .
+
+RUN APP_HOST=example.invalid SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile && \
+    rm -rf node_modules
+
+FROM base
+
+RUN groupadd --system --gid 1000 rails && \
+    useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash
+
+COPY --chown=rails:rails --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
+COPY --chown=rails:rails --from=build /rails /rails
+
+USER 1000:1000
+
+ENTRYPOINT ["/rails/bin/docker-entrypoint"]
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD curl --fail --silent --show-error "http://localhost:${PORT:-3000}/up" > /dev/null || exit 1
+
+CMD ["./bin/rails", "server"]

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ This is a little test app to try out AA 4. It works on top of a clone of the act
 Open http://localhost:3000
 
 A test user is in the seeds
+
+## Deployment
+
+See [Deploying with Coolify](docs/coolify.md) for the production container and
+Coolify configuration.

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+rm -f /rails/tmp/pids/server.pid
+
+exec "$@"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,8 +29,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # Coolify checks this endpoint over the container's internal HTTP connection.
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
@@ -56,7 +56,10 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APP_HOST"),
+    protocol: "https"
+  }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {
@@ -77,12 +80,7 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # Enable DNS rebinding protection while allowing Coolify's internal health check.
+  config.hosts << ENV.fetch("APP_HOST")
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/docs/coolify.md
+++ b/docs/coolify.md
@@ -1,0 +1,42 @@
+# Deploying with Coolify
+
+The application is deployed from the repository's `Dockerfile`. Use a regular
+Coolify application with the **Dockerfile** build pack rather than Docker
+Compose so rolling deployments remain available.
+
+## Application settings
+
+- Dockerfile: `/Dockerfile`
+- Exposed port: `3000`
+- Port mappings: none
+- Health check: `GET /up` on port `3000`, expected status `200`
+- Pre-deployment command: `./bin/rails db:prepare`
+- Start command: use the image default
+
+## Required environment variables
+
+| Variable | Value |
+| --- | --- |
+| `APP_HOST` | Public hostname without a scheme, for example `admin.example.com` |
+| `DATABASE_URL` | Internal URL of the Coolify PostgreSQL resource |
+| `RAILS_MASTER_KEY` | Contents of `config/master.key`; never commit this value |
+| `RAILS_ENV` | `production` |
+
+Recommended starting values for a small VPS are `RAILS_MAX_THREADS=3`,
+`WEB_CONCURRENCY=1`, and `PORT=3000`. Increase concurrency only after checking
+the application's memory usage and the PostgreSQL connection limit.
+
+## PostgreSQL and backups
+
+Create PostgreSQL as a separate Coolify resource and use its internal URL. Do
+not expose the database publicly. Configure scheduled backups and copy them to
+S3-compatible storage outside the VPS. Test restoring a backup before relying
+on the deployment for production data.
+
+## First deployment
+
+1. Configure the domain, environment variables, and PostgreSQL resource.
+2. Enable the `/up` health check and rolling deployments.
+3. Deploy the application.
+4. Verify the login flow and inspect the application logs.
+5. Confirm that a backup can be created and restored.


### PR DESCRIPTION
## Summary

- add a multi-stage production Docker image for Ruby 4.0.6 and the existing Rails/Active Admin assets
- run the container as an unprivileged user with a real `/up` Docker healthcheck
- configure production host authorization and mailer URLs through `APP_HOST`
- document Coolify, PostgreSQL, migration, healthcheck, and backup settings
- build the production image in GitHub Actions

## Verification

- `docker build --platform linux/amd64 --tag seepalette-admin:coolify-test .`
- production container became healthy and `GET /up` returned HTTP 200
- `bundle exec rspec --format progress` — 163 examples, 0 failures (85 pending)
- `bundle exec rails db:test:prepare test:all` — 14 runs, 30 assertions, 0 failures
- `bundle exec rails zeitwerk:check`
- production `assets:precompile`
